### PR TITLE
Omit labels where every field is blank

### DIFF
--- a/src/main/java/uk/ac/sanger/eln_pmb_bridge/PrintRequestHelper.java
+++ b/src/main/java/uk/ac/sanger/eln_pmb_bridge/PrintRequestHelper.java
@@ -98,10 +98,15 @@ public class PrintRequestHelper {
             }
 
             Map<String, String> fieldMap = new HashMap<>();
+            boolean anyValues = false;
             for (int i = 0; i < data.length; i++) {
-                fieldMap.put(columns.get(i), data[i].trim());
+                String value = data[i].trim();
+                anyValues |= !value.isEmpty();
+                fieldMap.put(columns.get(i), value);
             }
-            fields.add(fieldMap);
+            if (anyValues) {
+                fields.add(fieldMap);
+            }
         }
 
         List<PrintRequest.Label> labels = new ArrayList<>();


### PR DESCRIPTION
We've been getting requests today with rows of no data, just
,,,,
which causes empty label requests to be sent to the print service.
I am having those labels skipped in PrintRequestHelper.
